### PR TITLE
chore(): add gulp-plumber, fix paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,19 +1,20 @@
 var gulp = require('gulp');
 var del = require('del');
 var concat = require('gulp-concat');
+var plumber = require('gulp-plumber');
 var rename = require('gulp-rename');
 var traceur = require('gulp-traceur');
 
 var PATHS = {
     src: {
-        js: 'src/*.js',
-        html: 'src/*.html'
+      js: 'src/**/*.js',
+      html: 'src/**/*.html'
     },
     lib: [
-        'node_modules/gulp-traceur/node_modules/traceur/bin/traceur-runtime.js',
-        'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
-        'node_modules/systemjs/lib/extension-register.js',
-        'node_modules/angular2/node_modules/zone.js/zone.js'
+      'node_modules/gulp-traceur/node_modules/traceur/bin/traceur-runtime.js',
+      'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
+      'node_modules/systemjs/lib/extension-register.js',
+      'node_modules/angular2/node_modules/zone.js/zone.js'
     ]
 };
 
@@ -22,8 +23,9 @@ gulp.task('clean', function(done) {
 });
 
 gulp.task('js', function () {
-    return gulp.src('src/**/*.js')
+    return gulp.src(PATHS.src.js)
         .pipe(rename({extname: ''})) //hack, see: https://github.com/sindresorhus/gulp-traceur/issues/54
+        .pipe(plumber())
         .pipe(traceur({
             modules: 'instantiate',
             moduleName: true,

--- a/package.json
+++ b/package.json
@@ -16,12 +16,13 @@
     "connect": "^3.3.4",
     "del": "~1.1.1",
     "gulp": "~3.8.10",
-    "open": "0.0.5",
-    "through2": "~0.6.3",
-    "serve-static": "~1.8.1",
-    "gulp-rename": "~1.2.0",
     "gulp-concat": "~2.5.0",
-    "gulp-traceur": "0.16.*"
+    "gulp-plumber": "^1.0.0",
+    "gulp-rename": "~1.2.0",
+    "gulp-traceur": "0.16.*",
+    "open": "0.0.5",
+    "serve-static": "~1.8.1",
+    "through2": "~0.6.3"
   },
   "dependencies": {
     "angular2": "2.0.0-alpha.12",


### PR DESCRIPTION
gulp-plumber makes it so when traceur compile errors, it doesn't stop gulp. It only outputs the error.

Also fixed some whitespace and made the paths recursive.
