### PR TITLE
chore: Add "play" script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ The goal of this repo is to prepare a minimal ("walking skeleton") project build
 
 Clone this repo and execute in your favourite shell:
 
-* `npm i -g gulp` to install gulp globally (if you don't have it installed already)
 * `npm i` to install local npm dependencies
 
 ## Play
 
 After completing installation type in your favourite shell:
 
-* `gulp play` to start a "Hello World" app in a new browser window. App files are observed and will be re-transpiled on each change.
+* `npm run play` to start a "Hello World" app in a new browser window. App files are observed and will be re-transpiled on each change.
 
 ## Dependencies
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "ng2-play",
   "version": "0.0.0",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "play": "gulp play"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There are no needs to pollute global node_modules. This PR makes it possible to run "play" without installation of global gulp.
