### PR TITLE
Add sourcemaps support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var sourcemaps = require('gulp-sourcemaps');
 
 var PATHS = {
     src: {
+      root: 'src',
       js: 'src/**/*.js',
       html: 'src/**/*.html'
     },
@@ -36,7 +37,7 @@ gulp.task('js', function () {
             types: true
         }))
         .pipe(rename({extname: '.js'})) //hack, see: https://github.com/sindresorhus/gulp-traceur/issues/54
-        .pipe(sourcemaps.write('.'))
+        .pipe(sourcemaps.write('.', {sourceRoot: PATHS.src.root}))
         .pipe(gulp.dest('dist'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var concat = require('gulp-concat');
 var plumber = require('gulp-plumber');
 var rename = require('gulp-rename');
 var traceur = require('gulp-traceur');
+var sourcemaps = require('gulp-sourcemaps');
 
 var PATHS = {
     src: {
@@ -26,13 +27,16 @@ gulp.task('js', function () {
     return gulp.src(PATHS.src.js)
         .pipe(rename({extname: ''})) //hack, see: https://github.com/sindresorhus/gulp-traceur/issues/54
         .pipe(plumber())
+        .pipe(sourcemaps.init())
         .pipe(traceur({
+            sourceMaps: true,
             modules: 'instantiate',
             moduleName: true,
             annotations: true,
             types: true
         }))
         .pipe(rename({extname: '.js'})) //hack, see: https://github.com/sindresorhus/gulp-traceur/issues/54
+        .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest('dist'));
 });
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-concat": "~2.5.0",
     "gulp-plumber": "^1.0.0",
     "gulp-rename": "~1.2.0",
+    "gulp-sourcemaps": "1.1.*",
     "gulp-traceur": "0.16.*",
     "open": "0.0.5",
     "serve-static": "~1.8.1",


### PR DESCRIPTION
This PR makes gulp-traceur to emit sourcemaps (original sources will show up under src/ in Chrome's sources debug panel), which makes it possible to set breakpoints in the ES6+ source.

(thanks a lot for this handy repo!)
