### PR TITLE
chore(gulpfile.js): add workaround for rx auto-detection

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,6 +55,12 @@ gulp.task('angular2', function () {
     paths: {
       "angular2/*": "node_modules/angular2/es6/prod/*.es6",
       "rx": "node_modules/angular2/node_modules/rx/dist/rx.js"
+    },
+    meta: {
+      // auto-detection fails to detect properly here - https://github.com/systemjs/builder/issues/123
+      'rx': {
+        format: 'cjs'
+      }
     }
   };
 


### PR DESCRIPTION
This snippet is taken from Angular2 gulpfile.js
