### PR TITLE
Upgrade to v23

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,9 @@ var PATHS = {
       'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
       'node_modules/systemjs/lib/extension-register.js',
       'node_modules/angular2/node_modules/zone.js/zone.js',
-      'node_modules/angular2/node_modules/zone.js/long-stack-trace-zone.js'
+      'node_modules/angular2/node_modules/zone.js/long-stack-trace-zone.js',
+      'node_modules/reflect-metadata/Reflect.js',
+      'node_modules/reflect-metadata/Reflect.js.map'
     ]
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,8 @@ var PATHS = {
       'node_modules/gulp-traceur/node_modules/traceur/bin/traceur-runtime.js',
       'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
       'node_modules/systemjs/lib/extension-register.js',
-      'node_modules/angular2/node_modules/zone.js/zone.js',
-      'node_modules/angular2/node_modules/zone.js/long-stack-trace-zone.js',
+      'node_modules/angular2/node_modules/zone.js/dist/zone.js',
+      'node_modules/angular2/node_modules/zone.js/dist/long-stack-trace-zone.js',
       'node_modules/reflect-metadata/Reflect.js',
       'node_modules/reflect-metadata/Reflect.js.map'
     ]

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "through2": "~0.6.3"
   },
   "dependencies": {
-    "angular2": "2.0.0-alpha.22",
+    "angular2": "2.0.0-alpha.23",
     "es6-module-loader": "0.16.5",
+    "reflect-metadata": "^0.1.0",
     "systemjs": "0.16.7"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
     <script src="lib/traceur-runtime.js"></script>
     <script src="lib/es6-module-loader-sans-promises.src.js"></script>
     <script src="lib/extension-register.js"></script>
+    <script src="lib/Reflect.js"></script>
     <script>
         register(System);
     </script>


### PR DESCRIPTION
Couldn't find any reference to suggest that angular2 is packaging reflect-metadata itself so I have added the dependency? 
