### PR TITLE
Update SystemJS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "angular2": "2.0.0-alpha.44",
     "es6-shim": "^0.33.6",
-    "systemjs": "0.18.4"
+    "systemjs": "0.19.4"
   }
 }


### PR DESCRIPTION
There is a bug in the version of systemjs that you're using that prevented me from using my ng2-translate lib (defaultExtension doesn't work on sub folders): https://github.com/systemjs/systemjs/issues/805
