### PR TITLE
Update to support sourcemaps and pathLocationStrategy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,6 +31,17 @@ gulp.task('play', ['ts2js'], function () {
     gulp.watch(PATHS.src, ['ts2js']);
 
     app = connect().use(serveStatic(__dirname));
+    app.use(function (req, res) {
+        // redirect 404s to index.html
+        fs.readFile(__dirname + '/index.html', function (err, data) {
+            if (err) {
+                res.writeHead(500);
+                return res.end('Error loading index.html');
+            }
+            res.writeHead(200);
+            res.end(data);
+        });
+    }); 
     http.createServer(app).listen(port, function () {
         open('http://localhost:' + port);
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ gulp.task('ts2js', function () {
         .pipe(sourcemaps.init())
         .pipe(typescript(tscConfig.compilerOptions));
 
-    return tsResult.js.pipe(sourcemaps.write('../maps')).pipe(gulp.dest('dist'));
+    return tsResult.js.pipe(sourcemaps.write()).pipe(gulp.dest('dist'));
 });
 
 gulp.task('play', ['ts2js'], function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,13 +11,15 @@ gulp.task('clean', function (done) {
 
 gulp.task('ts2js', function () {
     var typescript = require('gulp-typescript');
+    var sourcemaps = require('gulp-sourcemaps');
     var tscConfig = require('./tsconfig.json');
 
     var tsResult = gulp
         .src(PATHS.src)
+        .pipe(sourcemaps.init())
         .pipe(typescript(tscConfig.compilerOptions));
 
-    return tsResult.js.pipe(gulp.dest('dist'));
+    return tsResult.js.pipe(sourcemaps.write('../maps')).pipe(gulp.dest('dist'));
 });
 
 gulp.task('play', ['ts2js'], function () {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "del": "^1.2.0",
     "gulp": "^3.9.0",
     "gulp-typescript": "^2.8.0",
+    "gulp-sourcemaps": "^1.6.0",
     "open": "0.0.5",
     "serve-static": "^1.10.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "target": "es5",
     "module": "system",
     "moduleResolution": "node",
-    "removeComments": true,
-    "sourceMap": false
+    "removeComments": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Made the following changes:
- gulpfile.js
  Added inline sourcemap support via gulp-sourcemaps (sourcemaps not supported in gulp-typescript)
  Added redirection of 404s to index.html. This allows pathLocationStrategy to work correctly if user hits reload/refresh in browser. Otherwise he receives an error "Cannot GET /foo"
- package.json
  Added gulp-sourcemaps
- tsconfig.json
  Removed entry sourcemaps

My first PR and I'm a total noob. So just disregard if inappropriate.
